### PR TITLE
Fix for ocramius 2.1+ file permission bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/app/logs/*
 reports/
 composer.phar
 composer.lock
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "emag/cache-bundle",
+  "name": "danieltoader/cache-bundle",
   "description": "CacheBundle by eMAGTechLabs",
   "type": "library",
   "license": "MIT",

--- a/src/ProxyManager/GeneratorStrategy/FileWriter.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Emag\CacheBundle\ProxyManager\GeneratorStrategy;
+
+use ProxyManager\GeneratorStrategy\GeneratorStrategyInterface;
+use Zend\Code\Generator\ClassGenerator;
+use ProxyManager\Exception\FileNotWritableException;
+use ProxyManager\FileLocator\FileLocatorInterface;
+
+/**
+ * Class FileWriter
+ *
+ * @package Emag\CacheBundle\ProxyManager\GeneratorStrategy
+ */
+class FileWriter implements GeneratorStrategyInterface
+{
+
+    /**
+     * @var \ProxyManager\FileLocator\FileLocatorInterface
+     */
+    protected $fileLocator;
+
+    /**
+     * @var callable
+     */
+    private $emptyErrorHandler;
+
+    /**
+     * @param \ProxyManager\FileLocator\FileLocatorInterface $fileLocator
+     */
+    public function __construct(FileLocatorInterface $fileLocator)
+    {
+        $this->fileLocator = $fileLocator;
+        $this->emptyErrorHandler = function () {
+        };
+    }
+
+    /**
+     * Write generated code to disk and return the class code
+     *
+     * {@inheritDoc}
+     *
+     * @throws FileNotWritableException
+     */
+    public function generate(ClassGenerator $classGenerator): string
+    {
+        $className = trim($classGenerator->getNamespaceName(), '\\')
+          .'\\'.trim($classGenerator->getName(), '\\');
+        $generatedCode = $classGenerator->generate();
+        $fileName = $this->fileLocator->getProxyFileName($className);
+
+        set_error_handler($this->emptyErrorHandler);
+
+        try {
+            $this->writeFile("<?php\n\n".$generatedCode, $fileName);
+
+            return $generatedCode;
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * Writes the source file in such a way that race conditions are avoided when the same file is written
+     * multiple times in a short time period
+     *
+     * @param string $source
+     * @param string $location
+     *
+     * @throws FileNotWritableException
+     */
+    private function writeFile(string $source, string $location)
+    {
+        $tmpFileName = tempnam($location, 'temporaryProxyManagerFile');
+
+        file_put_contents($tmpFileName, $source);
+        chmod($tmpFileName, 0666 & ~umask());
+
+        if (!rename($tmpFileName, $location)) {
+            unlink($tmpFileName);
+
+            throw FileNotWritableException::fromInvalidMoveOperation($tmpFileName, $location);
+        }
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,7 +5,7 @@ parameters:
     emag.cache.proxy.manager.class: Emag\CacheBundle\ProxyManager\Factory\ProxyCachingObjectFactory
     emag.cache.proxy.generator.class: Emag\CacheBundle\ProxyManager\ProxyGenerator\CachedObjectGenerator
     emag.cache.proxy.configuration.class: ProxyManager\Configuration
-    emag.cache.proxy.persister.class: ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy
+    emag.cache.proxy.persister.class: Emag\CacheBundle\ProxyManager\GeneratorStrategy\FileWriter
     emag.cache.proxy.locator.class: ProxyManager\FileLocator\FileLocator
     emag.cache.proxy.cache-locator.class: Symfony\Component\DependencyInjection\ServiceLocator
 


### PR DESCRIPTION
Ocramius ProxyManager introduced a bug starting with v2.1+ and will not fix it in 2.*. This pull request was needed in order to avoid waiting for v3.0+. Submitted bug: https://github.com/Ocramius/ProxyManager/issues/432

+ FileWriter that implements GeneratorStrategyInterface
* Added .idea folder to ignore list
* Changed emag.cache.proxy.persister.class to use the new FileWriter class
